### PR TITLE
Improve docker image

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -38,5 +38,5 @@ jobs:
             - docker-ce
       script:
         - docker build -t openapi-validator .
-        - docker run --rm -it openapi-validator python /opt/validator.py https://raw.githubusercontent.com/OAI/OpenAPI-Specification/master/examples/v3.0/petstore.yaml
+        - docker run --rm -it openapi-validator https://raw.githubusercontent.com/OAI/OpenAPI-Specification/master/examples/v3.0/petstore.yaml
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,9 @@
-FROM circleci/python:3.6-jessie
+FROM python:3.6-alpine
 
-COPY requirements.txt /opt/
-COPY validator.py /opt/
+COPY requirements.txt /opt/openapi-validator/
+COPY validator.py /opt/openapi-validator/
 
-RUN sudo pip install -r /opt/requirements.txt
+RUN pip install -r /opt/openapi-validator/requirements.txt
+
+ENTRYPOINT ["python", "/opt/openapi-validator/validator.py"]
 

--- a/README.md
+++ b/README.md
@@ -10,36 +10,29 @@ specification](https://github.com/OAI/OpenAPI-Specification/blob/master/versions
 
 ## Usage
 
-### CI server
 
-We currently use Circle-CI to validate our pull requests, and their new
-configuration format (v2) allows us to use customised docker images to run the
-jobs. So we just had to add this workflow job:
-
-```yml
-  validate-spec:
-    docker:
-      - image: usabillabv/openapi3-validator
-    steps:
-      - checkout
-      - run: python /opt/validator.py <path to your file>
-```
-
-### Development
-
-We can also use this image locally by running the following command (on the root
-folder of your project:
+First you need to pull the image from [Docker Hub](https://hub.docker.com):
 
 ```sh
-$ docker run -it --rm -v ${PWD}:/project -w /project usabillabv/openapi3-validator python /opt/validator.py <path to your file>
+docker pull usabillabv/openapi3-validator
+```
+
+Then you can use it to validate specs available on a shared volume:
+
+```sh
+$ docker run -it --rm -v ${PWD}:/project -w /project usabillabv/openapi3-validator <path to your file>
+```
+
+Or available via an HTTP(s) endpoint:
+
+```sh
+$ docker run -it --rm usabillabv/openapi3-validator <uri>
 ```
 
 Optionally you can create an alias and just use it, like:
 
 ```sh
-$ alias openapi3-validate="docker run -it --rm -v ${PWD}:/project -w /project usabillabv/openapi3-validator python /opt/validator.py"
-$ openapi3-validate <path to your file>
+$ alias openapi3-validate="docker run -it --rm -v ${PWD}:/project -w /project usabillabv/openapi3-validator"
+$ openapi3-validate <path to your file or uri>
 ```
 
-The output is not really friendly but it does the basic stuff (exit code is
-correct).


### PR DESCRIPTION
Using `python:3.6-alpine` as base and turning it into an executable container.