### PR TITLE
Add release action workflow

### DIFF
--- a/.github/workflows/release-action.yaml
+++ b/.github/workflows/release-action.yaml
@@ -1,0 +1,37 @@
+name: release-action
+on:
+  push:
+    tags:
+      - '[0-9]+.[0-9]+.[0-9]+'
+jobs:
+  create-release:
+    runs-on: ubuntu-20.04
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          ref: ${{github.ref_name}}
+      - name: Create release
+        uses: ncipollo/release-action@v1
+        with:
+          tag: ${{github.ref_name}}
+      - name: Set up docker buildx
+        uses: docker/setup-buildx-action@v1
+        with:
+          driver-opts: network=host
+      - name: Login to DockerHub
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.CONTAINER_REGISTRY_USERNAME }}
+          password: ${{ secrets.CONTAINER_REGISTRY_PASSWORD }}
+      - name: Build and push docker image
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          builder: ${{ steps.buildx.outputs.name }}
+          push: true
+          tags: |
+            usabillabv/openapi3-validator:latest
+            usabillabv/openapi3-validator:${{github.ref_name}}

--- a/.github/workflows/smoke-tests-action.yml
+++ b/.github/workflows/smoke-tests-action.yml
@@ -4,7 +4,7 @@ on:
     types: [opened, synchronize]
 jobs:
   build-docker-run-tests:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     services:
       registry:
         image: registry:2


### PR DESCRIPTION
The basic idea here is to trigger this workflow on tag push and perform the following steps:
- Create a new release. _ncipollo/release-action@v1_ uses tag description as a release description
- Build docker image and push it into public docker hub repo

