### PR TITLE
Fix legacy mode using issue

### DIFF
--- a/.github/workflows/smoke-tests-action.yml
+++ b/.github/workflows/smoke-tests-action.yml
@@ -72,3 +72,6 @@ jobs:
           openapi3-validate --path /project --spec-name '*openapi.yaml' 
           # lookup spec by custom names
           openapi3-validate -p /project -n foo-openapi.yaml -n bar-openapi.yaml
+      - name: Legacy validator script run
+        run: |
+          docker run --rm -v $(pwd):/project -w /project --entrypoint python localhost:5000/openapi-validator /opt/openapi-validator/validator.py /project/path/to/foo-openapi.yaml

--- a/validator.py
+++ b/validator.py
@@ -69,3 +69,22 @@ def print_error(count, path, message, instance):
     )
     print("    %s" % message)
     print("    %s" % instance)
+
+
+# For legacy mode only - some existing pipelines override docker image entry point
+# and use this validator.py module directly instead of main one
+def help():
+    print('usage: ' + path.basename(__file__) + ' <spec>')
+
+
+def main(argv):
+    if len(argv) == 0:
+        print('Invalid usage!')
+        help()
+        sys.exit(2)
+
+    sys.exit(validate(argv[0]))
+
+
+if __name__ == "__main__":
+    main(sys.argv[1:])


### PR DESCRIPTION
Some existing pipelines override the docker image entry point and use the validator.py script directly instead of the main one.
Added test for this usage mode.