### PR TITLE
Add possibility to not fail validation if spec file is missing

### DIFF
--- a/.github/workflows/smoke-tests-action.yml
+++ b/.github/workflows/smoke-tests-action.yml
@@ -61,6 +61,8 @@ jobs:
           # normal mode checks
           openapi3-validate --file /project/path/to/foo-openapi.yaml --file /project/path/to/specs/bar-openapi.yaml
           openapi3-validate -f /project/path/openapi.yaml
+          # negative scenario check - ignore-missing-spec should't work for direct file path
+          ! openapi3-validate -f /project/non/existing/file.yaml -i
       - name: Spec lookup tests
         run: |
           # Create an alias
@@ -70,6 +72,8 @@ jobs:
           openapi3-validate --path /project
           # lookup spec by custom name with wildcard
           openapi3-validate --path /project --spec-name '*openapi.yaml' 
+          # check --ignore-missing-spec argument
+          openapi3-validate --path /project --spec-name non-existing-spec.yaml --ignore-missing-spec
           # lookup spec by custom names
           openapi3-validate -p /project -n foo-openapi.yaml -n bar-openapi.yaml
       - name: Legacy validator script run

--- a/README.md
+++ b/README.md
@@ -29,6 +29,8 @@ options:
   -p PATH, --path PATH  open api spec files lookup path
   -n SPEC_NAME, --spec-name SPEC_NAME
                         open api spec file name, multiple arguments are supported. Used in conjunction with --path option. Default value: openapi.yaml
+  -i, --ignore-missing-spec
+                        do not fail processing if spec file is missing. Used in conjunction with --path option.                      
 ```
 
 Then you can use it to validate specs available on a shared volume.

--- a/main.py
+++ b/main.py
@@ -43,6 +43,9 @@ def init_args_parser():
                         help="open api spec file name, multiple arguments are supported. " +
                              "Used in conjunction with --path option. Default value: " +
                              ','.join(_DEFAULT_OPEN_API_SPEC_NAMES))
+    parser.add_argument("-i", "--ignore-missing-spec",
+                        help="do not fail processing if spec file is missing. Used in conjunction with --path option.",
+                        action="store_true")
     return parser
 
 
@@ -77,7 +80,8 @@ def get_spec_file_paths(args, spec_file_names):
     else:
         spec_file_paths = args.url
 
-    if len(spec_file_paths) == 0:
+    # ignore_missing_spec should be working only if path argument is present
+    if len(spec_file_paths) == 0 and not args.ignore_missing_spec and args.path is not None:
         print(
             color(
                 ' [FAIL] open api spec is not found',


### PR DESCRIPTION
Open api spec validation tool is going to be used in scope of common CI step for different projects.
Some of them still don't have open api spec. So, new --ignore-missing-spec command line argument is added.
It works only with --path option and should help to not break CI pipeline for such projects.