### PR TITLE
Update default spec name value

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ options:
   -u URL, --url URL     uri to open api spec, multiple arguments are supported
   -p PATH, --path PATH  open api spec files lookup path
   -n SPEC_NAME, --spec-name SPEC_NAME
-                        open api spec file name, multiple arguments are supported. Used in conjunction with --path option. Default value: openapi.yaml
+                        open api spec file name, multiple arguments are supported. Used in conjunction with --path option. Default value: *openapi.yaml, *openapi.yml
   -i, --ignore-missing-spec
                         do not fail processing if spec file is missing. Used in conjunction with --path option.                      
 ```

--- a/main.py
+++ b/main.py
@@ -4,7 +4,7 @@ from validator import validate
 from lookup import files_lookup
 from colors import color
 
-_DEFAULT_OPEN_API_SPEC_NAMES = {"openapi.yaml"}
+_DEFAULT_OPEN_API_SPEC_NAMES = {"*openapi.yaml", "*openapi.yml"}
 
 
 def main(argv):


### PR DESCRIPTION
It should help to cover by default value multiple spec files, like first-entity-openapi.yaml, second-entity-openapi.yaml.