### PR TITLE
Rename --path argument to --lookup-path as the second one is more sel…

### DIFF
--- a/.github/workflows/smoke-tests-action.yml
+++ b/.github/workflows/smoke-tests-action.yml
@@ -69,11 +69,11 @@ jobs:
           shopt -s expand_aliases
           alias openapi3-validate='docker run --rm -v $(pwd):/project -w /project localhost:5000/openapi-validator'
           # lookup spec by default name openapi.yaml
-          openapi3-validate --path /project
+          openapi3-validate --lookup-path /project
           # lookup spec by custom name with wildcard
-          openapi3-validate --path /project --spec-name '*openapi.yaml' 
+          openapi3-validate --lookup-path /project --spec-name '*openapi.yaml' 
           # check --ignore-missing-spec argument
-          openapi3-validate --path /project --spec-name non-existing-spec.yaml --ignore-missing-spec
+          openapi3-validate --lookup-path /project --spec-name non-existing-spec.yaml --ignore-missing-spec
           # lookup spec by custom names
           openapi3-validate -p /project -n foo-openapi.yaml -n bar-openapi.yaml
       - name: Legacy validator script run

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ docker pull usabillabv/openapi3-validator
 
 The validator can be run with the following arguments:
 ```sh
-usage: [-h] (-f FILE | -u URL | -p PATH) [-n SPEC_NAME]
+usage: main.py [-h] (-f FILE | -u URL | -p LOOKUP_PATH) [-n SPEC_NAME] [-i]
 
 Open API spec validation tool
 
@@ -26,11 +26,13 @@ options:
   -h, --help            show this help message and exit
   -f FILE, --file FILE  full path to open api spec file, multiple arguments are supported
   -u URL, --url URL     uri to open api spec, multiple arguments are supported
-  -p PATH, --path PATH  open api spec files lookup path
+  -p LOOKUP_PATH, --lookup-path LOOKUP_PATH
+                        open api spec files lookup path
   -n SPEC_NAME, --spec-name SPEC_NAME
-                        open api spec file name, multiple arguments are supported. Used in conjunction with --path option. Default value: *openapi.yaml, *openapi.yml
+                        open api spec file name, multiple arguments are supported. Used in conjunction with --lookup-path option. Default value:
+                        *openapi.yml,*openapi.yaml
   -i, --ignore-missing-spec
-                        do not fail processing if spec file is missing. Used in conjunction with --path option.                      
+                        do not fail processing if spec file is missing. Used in conjunction with --lookup-path option.                     
 ```
 
 Then you can use it to validate specs available on a shared volume.

--- a/main.py
+++ b/main.py
@@ -36,15 +36,15 @@ def init_args_parser():
     group.add_argument("-u", "--url",
                        action='append',
                        help="uri to open api spec, multiple arguments are supported")
-    group.add_argument("-p", "--path",
+    group.add_argument("-p", "--lookup-path",
                        help="open api spec files lookup path")
     parser.add_argument("-n", "--spec-name",
                         action='append',
                         help="open api spec file name, multiple arguments are supported. " +
-                             "Used in conjunction with --path option. Default value: " +
+                             "Used in conjunction with --lookup-path option. Default value: " +
                              ','.join(_DEFAULT_OPEN_API_SPEC_NAMES))
     parser.add_argument("-i", "--ignore-missing-spec",
-                        help="do not fail processing if spec file is missing. Used in conjunction with --path option.",
+                        help="do not fail processing if spec file is missing. Used in conjunction with --lookup-path option.",
                         action="store_true")
     return parser
 
@@ -73,15 +73,15 @@ def perform_validation(args):
 
 
 def get_spec_file_paths(args, spec_file_names):
-    if args.path is not None:
-        spec_file_paths = files_lookup(args.path, spec_file_names)
+    if args.lookup_path is not None:
+        spec_file_paths = files_lookup(args.lookup_path, spec_file_names)
     elif args.file is not None:
         spec_file_paths = args.file
     else:
         spec_file_paths = args.url
 
     # ignore_missing_spec should be working only if path argument is present
-    if len(spec_file_paths) == 0 and not args.ignore_missing_spec and args.path is not None:
+    if len(spec_file_paths) == 0 and not args.ignore_missing_spec and args.lookup_path is not None:
         print(
             color(
                 ' [FAIL] open api spec is not found',


### PR DESCRIPTION
 Rename --path argument to --lookup-path as the second one is more self-explaining

This is a BREAKING change in theory, but taking into account that release with the previous name was 2 days ago and existing pipelines use the tool in legacy mode it shouldn't be a big deal.
